### PR TITLE
feat: publish governance platform customer packages

### DIFF
--- a/.github/workflows/docsite-ci.yaml
+++ b/.github/workflows/docsite-ci.yaml
@@ -1,0 +1,104 @@
+---
+name: Docsite CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/docsite-ci.yaml"
+      - "docs-site/**"
+      - "releases/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/docsite-ci.yaml"
+      - "docs-site/**"
+      - "releases/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docsite-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install yq
+        run: |
+          sudo curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Validate required docs source
+        run: |
+          required=(
+            "docs-site/readme/guides/release-overview.md"
+            "docs-site/readme/guides/install/connected-install.md"
+            "docs-site/readme/guides/install/airgap-install.md"
+            "docs-site/readme/guides/upgrade/upgrade.md"
+            "docs-site/readme/guides/upgrade/rollback.md"
+            "docs-site/readme/guides/operate/known-issues.md"
+            "docs-site/readme/reference/release-manifest.md"
+          )
+
+          for file in "${required[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "::error::Missing required docsite source file: ${file}"
+              exit 1
+            fi
+          done
+
+      - name: Validate release metadata links
+        run: |
+          shopt -s nullglob
+          for manifest in releases/v*/release-manifest.yaml; do
+            docs_version="$(yq '.docs.version' "$manifest")"
+            docs_state="$(yq '.docs.state' "$manifest")"
+
+            if [ -z "$docs_version" ] || [ "$docs_version" = "null" ]; then
+              echo "::error file=${manifest}::docs.version is required"
+              exit 1
+            fi
+
+            case "$docs_state" in
+              beta|public|hidden|deprecated) ;;
+              *)
+                echo "::error file=${manifest}::docs.state must be beta, public, hidden, or deprecated"
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Prevent release doc drift
+        run: |
+          if grep -RIn --include='*.md' ':latest' docs-site releases 2>/dev/null; then
+            echo "::error::Docsite source must not recommend latest image tags."
+            exit 1
+          fi
+
+          if grep -RIn --include='*.md' 'gke_eqtylab\|internal\.eqtylab\|localhost:[0-9]' docs-site releases 2>/dev/null; then
+            echo "::error::Docsite source appears to include internal-only or local URLs."
+            exit 1
+          fi
+
+      - name: Validate local markdown links
+        run: |
+          missing=0
+          while IFS= read -r file; do
+            while IFS= read -r link; do
+              target="${link%%#*}"
+              [ -z "$target" ] && continue
+              case "$target" in
+                http://*|https://*|mailto:*|/*) continue ;;
+              esac
+              if [ ! -e "$(dirname "$file")/$target" ]; then
+                echo "::error file=${file}::Broken local link: ${link}"
+                missing=1
+              fi
+            done < <(grep -oE '\]\(([^)]+)\)' "$file" | sed -E 's/^\]\(([^)]+)\)$/\1/' || true)
+          done < <(find docs-site -name '*.md' -print)
+
+          exit "$missing"

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -1,0 +1,156 @@
+---
+name: Helm CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/helm-ci.yaml"
+      - "charts/**"
+      - "releases/**"
+      - "docs-site/**"
+      - "schemas/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/helm-ci.yaml"
+      - "charts/**"
+      - "releases/**"
+      - "docs-site/**"
+      - "schemas/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  helm-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.20.0
+
+      - name: Install yq
+        run: |
+          sudo curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Refuse committed packaged charts
+        run: |
+          if find charts -name '*.tgz' -print -quit | grep -q .; then
+            echo "::error::Do not commit generated chart .tgz archives."
+            find charts -name '*.tgz' -print
+            exit 1
+          fi
+
+      - name: Build umbrella dependencies
+        run: helm dependency build charts/governance-platform
+
+      - name: Lint charts
+        run: |
+          for chart in charts/*; do
+            if [ -f "$chart/Chart.yaml" ]; then
+              helm lint "$chart"
+            fi
+          done
+
+      - name: Template supported install paths
+        run: |
+          helm template governance-platform charts/governance-platform >/dev/null
+          helm template governance-platform charts/governance-platform \
+            --values charts/governance-platform/examples/values-keycloak.yaml \
+            --values charts/governance-platform/examples/values-external-postgres.yaml \
+            >/dev/null
+          helm template governance-platform charts/governance-platform \
+            --values charts/governance-platform/examples/values-auth0.yaml \
+            --values charts/governance-platform/examples/values-external-postgres.yaml \
+            >/dev/null
+          helm template governance-platform charts/governance-platform \
+            --values charts/governance-platform/examples/values-entra.yaml \
+            --values charts/governance-platform/examples/values-external-postgres.yaml \
+            >/dev/null
+
+      - name: Template registry override paths
+        run: |
+          helm template governance-platform charts/governance-platform \
+            --set global.imageRegistryOverride=registry.customer.example \
+            >/tmp/registry-override.yaml
+          helm template governance-platform charts/governance-platform \
+            --set global.imageRepositoryPrefixOverride=registry.customer.example/eqtylab \
+            >/tmp/repository-prefix-override.yaml
+
+          grep -q 'registry.customer.example/eqtylab/governance-studio' /tmp/repository-prefix-override.yaml
+          grep -q 'registry.customer.example/eqtylab/governance-service' /tmp/repository-prefix-override.yaml
+          grep -q 'registry.customer.example/eqtylab/auth-service' /tmp/repository-prefix-override.yaml
+          grep -q 'registry.customer.example/eqtylab/integrity-service' /tmp/repository-prefix-override.yaml
+
+      - name: Validate release manifests
+        run: |
+          shopt -s nullglob
+          for manifest in releases/v*/release-manifest.yaml; do
+            version="$(yq '.platform.version' "$manifest")"
+            release_type="$(yq '.platform.releaseType' "$manifest")"
+
+            if [ -z "$version" ] || [ "$version" = "null" ]; then
+              echo "::error file=${manifest}::Missing platform.version"
+              exit 1
+            fi
+
+            case "$release_type" in
+              prerelease|stable) ;;
+              *)
+                echo "::error file=${manifest}::platform.releaseType must be prerelease or stable"
+                exit 1
+                ;;
+            esac
+
+            validation_mode="$(yq '.validation.mode' "$manifest")"
+            validation_status="$(yq '.validation.evidence.status' "$manifest")"
+
+            if [ "$validation_mode" != "manual" ]; then
+              echo "::error file=${manifest}::validation.mode must be manual"
+              exit 1
+            fi
+
+            case "$validation_status" in
+              pending|approved|rejected) ;;
+              *)
+                echo "::error file=${manifest}::validation.evidence.status must be pending, approved, or rejected"
+                exit 1
+                ;;
+            esac
+
+            for chart in auth-service governance-service governance-studio integrity-service governance-platform; do
+              chart_version="$(yq '.version' "charts/${chart}/Chart.yaml")"
+              if [ "$chart_version" != "$version" ]; then
+                echo "::error file=charts/${chart}/Chart.yaml::Expected chart version ${version}; found ${chart_version}"
+                exit 1
+              fi
+            done
+
+            for image in authService governanceService governanceStudio integrityService; do
+              tag="$(yq ".images.${image}.tag" "$manifest")"
+              digest="$(yq ".images.${image}.digest" "$manifest")"
+              if [ "$tag" != "$version" ]; then
+                echo "::error file=${manifest}::${image} tag must match platform version ${version}"
+                exit 1
+              fi
+              if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+                echo "::error file=${manifest}::${image} digest is required"
+                exit 1
+              fi
+            done
+          done
+
+      - name: Prevent latest image tags in release-facing files
+        run: |
+          if grep -RIn --include='*.yaml' --include='*.yml' --include='*.md' ':latest' charts releases docs-site 2>/dev/null; then
+            echo "::error::Customer release files must not reference latest image tags."
+            exit 1
+          fi

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -35,6 +35,11 @@ jobs:
         with:
           version: v3.20.0
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update bitnami
+
       - name: Install yq
         run: |
           sudo curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \

--- a/.github/workflows/release-platform-package.yaml
+++ b/.github/workflows/release-platform-package.yaml
@@ -45,6 +45,11 @@ jobs:
         with:
           version: v3.20.0
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update bitnami
+
       - name: Install yq
         run: |
           sudo curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \

--- a/.github/workflows/release-platform-package.yaml
+++ b/.github/workflows/release-platform-package.yaml
@@ -1,0 +1,370 @@
+---
+name: Release Platform Package
+
+on:
+  push:
+    tags:
+      - "platform/v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Platform version without leading v, for dry-run packaging"
+        required: true
+        type: string
+      publish:
+        description: "Publish charts and GitHub Release"
+        required: false
+        default: false
+        type: boolean
+      build_airgap:
+        description: "Build optional air-gap package"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+  attestations: write
+  id-token: write
+
+concurrency:
+  group: platform-package-${{ github.ref_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: customer-release-publication
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.20.0
+
+      - name: Install yq
+        run: |
+          sudo curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Resolve release
+        id: release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            version="${GITHUB_REF_NAME#platform/v}"
+            publish="true"
+          else
+            version="$INPUT_VERSION"
+            publish="${{ inputs.publish }}"
+          fi
+
+          manifest="releases/v${version}/release-manifest.yaml"
+          if [ ! -f "$manifest" ]; then
+            echo "::error::Missing release manifest: ${manifest}"
+            exit 1
+          fi
+
+          release_type="$(yq '.platform.releaseType' "$manifest")"
+          if [ "$release_type" = "prerelease" ]; then
+            prerelease="true"
+          else
+            prerelease="false"
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "manifest=${manifest}" >> "$GITHUB_OUTPUT"
+          echo "release_type=${release_type}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release manifest
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          MANIFEST: ${{ steps.release.outputs.manifest }}
+          PUBLISH: ${{ steps.release.outputs.publish }}
+        run: |
+          manifest_version="$(yq '.platform.version' "$MANIFEST")"
+          if [ "$manifest_version" != "$VERSION" ]; then
+            echo "::error file=${MANIFEST}::Manifest version ${manifest_version} does not match ${VERSION}."
+            exit 1
+          fi
+
+          validation_mode="$(yq '.validation.mode' "$MANIFEST")"
+          validation_status="$(yq '.validation.evidence.status' "$MANIFEST")"
+
+          if [ "$validation_mode" != "manual" ]; then
+            echo "::error file=${MANIFEST}::validation.mode must be manual."
+            exit 1
+          fi
+
+          if [ "$PUBLISH" = "true" ] && [ "$validation_status" != "approved" ]; then
+            echo "::error file=${MANIFEST}::Customer publication requires validation.evidence.status=approved."
+            exit 1
+          fi
+
+          for service in authService governanceService governanceStudio integrityService; do
+            tag="$(yq ".images.${service}.tag" "$MANIFEST")"
+            digest="$(yq ".images.${service}.digest" "$MANIFEST")"
+            if [ "$tag" != "$VERSION" ]; then
+              echo "::error file=${MANIFEST}::${service} image tag must be ${VERSION}."
+              exit 1
+            fi
+            if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+              echo "::error file=${MANIFEST}::${service} digest is required."
+              exit 1
+            fi
+          done
+
+          for chart in auth-service governance-service governance-studio integrity-service governance-platform; do
+            chart_version="$(yq '.version' "charts/${chart}/Chart.yaml")"
+            app_version="$(yq '.appVersion' "charts/${chart}/Chart.yaml")"
+            if [ "$chart_version" != "$VERSION" ]; then
+              echo "::error file=charts/${chart}/Chart.yaml::Expected chart version ${VERSION}; got ${chart_version}."
+              exit 1
+            fi
+            if [ "$app_version" != "$VERSION" ]; then
+              echo "::error file=charts/${chart}/Chart.yaml::Expected appVersion ${VERSION}; got ${app_version}."
+              exit 1
+            fi
+          done
+
+      - name: Helm validation
+        run: |
+          helm dependency build charts/governance-platform
+          for chart in charts/auth-service charts/governance-service charts/governance-studio charts/integrity-service charts/governance-platform; do
+            helm lint "$chart"
+          done
+          helm template governance-platform charts/governance-platform >/dev/null
+          helm template governance-platform charts/governance-platform \
+            --values charts/governance-platform/examples/values-keycloak.yaml \
+            --values charts/governance-platform/examples/values-external-postgres.yaml \
+            >/dev/null
+          helm template governance-platform charts/governance-platform \
+            --set global.imageRepositoryPrefixOverride=registry.customer.example/eqtylab \
+            >/dev/null
+
+      - name: Login to GHCR
+        if: steps.release.outputs.publish == 'true'
+        run: echo "${{ github.token }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Publish platform charts
+        id: charts
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          PUBLISH: ${{ steps.release.outputs.publish }}
+        run: |
+          mkdir -p dist/charts
+          chart_digest_file="dist/chart-digests.yaml"
+          echo "charts:" > "$chart_digest_file"
+
+          publish_chart() {
+            local chart="$1"
+            local chart_dir="charts/${chart}"
+            local oci_ref="oci://ghcr.io/eqtylab/charts/${chart}"
+            local package_path
+            local digest
+            local package_sha
+
+            if [ "$chart" = "governance-platform" ]; then
+              helm dependency build "$chart_dir"
+            fi
+
+            if [ "$PUBLISH" = "true" ] && helm show chart "$oci_ref" --version "$VERSION" >/dev/null 2>&1; then
+              echo "${oci_ref}:${VERSION} already exists; pulling for package assembly."
+              helm pull "$oci_ref" --version "$VERSION" --destination dist/charts
+              package_path="dist/charts/${chart}-${VERSION}.tgz"
+              digest="existing"
+            else
+              helm package "$chart_dir" --destination dist/charts
+              package_path="dist/charts/${chart}-${VERSION}.tgz"
+
+              if [ "$PUBLISH" = "true" ]; then
+                helm push "$package_path" oci://ghcr.io/eqtylab/charts | tee "dist/charts/${chart}-push.log"
+                digest="$(awk '/Digest:/ {print $2; exit}' "dist/charts/${chart}-push.log")"
+                if [ -z "$digest" ]; then
+                  echo "::error::Could not parse OCI digest for ${chart}."
+                  exit 1
+                fi
+              else
+                digest="dry-run"
+              fi
+            fi
+
+            package_sha="$(sha256sum "$package_path" | awk '{print $1}')"
+            sha256sum "$package_path" > "${package_path}.sha256"
+
+            cat >> "$chart_digest_file" <<EOF
+            ${chart}:
+              version: ${VERSION}
+              oci: ${oci_ref}
+              ociDigest: ${digest}
+              package: $(basename "$package_path")
+              packageSha256: ${package_sha}
+          EOF
+          }
+
+          for chart in auth-service governance-service governance-studio integrity-service governance-platform; do
+            publish_chart "$chart"
+          done
+
+      - name: Build connected customer package
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          MANIFEST: ${{ steps.release.outputs.manifest }}
+        run: |
+          package_root="dist/governance-platform-v${VERSION}"
+          mkdir -p "$package_root/charts" "$package_root/docs" "$package_root/examples"
+
+          cp "$MANIFEST" "$package_root/release-manifest.yaml"
+          cp dist/chart-digests.yaml "$package_root/chart-digests.yaml"
+          cp dist/charts/*.tgz "$package_root/charts/"
+          cp dist/charts/*.sha256 "$package_root/charts/"
+          cp -R charts/governance-platform/examples "$package_root/examples/governance-platform"
+
+          if [ -d docs-site ]; then
+            cp -R docs-site "$package_root/docs/docs-site"
+          fi
+
+          cat > "$package_root/INSTALL.md" <<EOF
+          # Governance Platform v${VERSION}
+
+          Install the customer release with the published umbrella chart:
+
+          \`\`\`bash
+          helm upgrade --install governance-platform oci://ghcr.io/eqtylab/charts/governance-platform \\
+            --version ${VERSION} \\
+            --namespace governance \\
+            --create-namespace \\
+            --values values.yaml
+          \`\`\`
+
+          Runtime images are private. Configure image pull credentials or mirror the images to a customer registry before installing.
+          EOF
+
+          (cd dist && tar -czf "governance-platform-v${VERSION}.tar.gz" "governance-platform-v${VERSION}")
+          sha256sum "dist/governance-platform-v${VERSION}.tar.gz" > "dist/governance-platform-v${VERSION}.tar.gz.sha256"
+          sha256sum dist/charts/*.tgz > dist/CHARTS.sha256
+
+      - name: Build optional air-gap package
+        if: inputs.build_airgap == true
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          package_root="dist/governance-platform-v${VERSION}-airgap"
+          mkdir -p "$package_root/images" "$package_root/charts" "$package_root/scripts"
+          cp dist/charts/*.tgz "$package_root/charts/"
+          cp "releases/v${VERSION}/release-manifest.yaml" "$package_root/release-manifest.yaml"
+
+          cat > "$package_root/scripts/mirror-images.sh" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          if [ "$#" -ne 1 ]; then
+            echo "usage: $0 <target-registry-prefix>" >&2
+            exit 1
+          fi
+
+          echo "Mirror the images listed in release-manifest.yaml to: $1"
+          echo "This package is chart-ready; image archive export is enabled in a later milestone."
+          EOF
+          chmod +x "$package_root/scripts/mirror-images.sh"
+
+          (cd dist && tar -czf "governance-platform-v${VERSION}-airgap.tar.gz" "governance-platform-v${VERSION}-airgap")
+          sha256sum "dist/governance-platform-v${VERSION}-airgap.tar.gz" > "dist/governance-platform-v${VERSION}-airgap.tar.gz.sha256"
+
+      - name: Verify package
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          mkdir -p /tmp/package-check
+          tar -xzf "dist/governance-platform-v${VERSION}.tar.gz" -C /tmp/package-check
+          test -f "/tmp/package-check/governance-platform-v${VERSION}/release-manifest.yaml"
+          test -f "/tmp/package-check/governance-platform-v${VERSION}/chart-digests.yaml"
+          helm template governance-platform "dist/charts/governance-platform-${VERSION}.tgz" >/dev/null
+
+      - name: Attest release packages
+        if: steps.release.outputs.publish == 'true'
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            dist/governance-platform-v${{ steps.release.outputs.version }}.tar.gz
+            dist/charts/*.tgz
+
+      - name: Create release notes
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_TYPE: ${{ steps.release.outputs.release_type }}
+        run: |
+          notes="dist/release-notes.md"
+          cat > "$notes" <<EOF
+          ## Governance Platform v${VERSION}
+
+          Release type: \`${RELEASE_TYPE}\`
+
+          ### Install
+
+          \`\`\`bash
+          helm upgrade --install governance-platform oci://ghcr.io/eqtylab/charts/governance-platform \\
+            --version ${VERSION} \\
+            --namespace governance \\
+            --create-namespace \\
+            --values values.yaml
+          \`\`\`
+
+          ### Artifacts
+
+          - Connected package: \`governance-platform-v${VERSION}.tar.gz\`
+          - Release manifest: \`release-manifest.yaml\`
+          - Chart digests: \`chart-digests.yaml\`
+          - Runtime image tags: \`${VERSION}\`
+
+          This release uses private runtime images. Customers must configure GHCR image pull credentials or mirror images into their own registry.
+          EOF
+
+      - name: Publish GitHub release
+        if: steps.release.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.version }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
+        run: |
+          tag="platform/v${VERSION}"
+          assets=(
+            "dist/governance-platform-v${VERSION}.tar.gz"
+            "dist/governance-platform-v${VERSION}.tar.gz.sha256"
+            "dist/CHARTS.sha256"
+            "dist/chart-digests.yaml"
+            "releases/v${VERSION}/release-manifest.yaml"
+          )
+
+          if [ -f "dist/governance-platform-v${VERSION}-airgap.tar.gz" ]; then
+            assets+=("dist/governance-platform-v${VERSION}-airgap.tar.gz")
+            assets+=("dist/governance-platform-v${VERSION}-airgap.tar.gz.sha256")
+          fi
+
+          flags=()
+          if [ "$PRERELEASE" = "true" ]; then
+            flags+=(--prerelease)
+          else
+            flags+=(--latest)
+          fi
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" "${assets[@]}" --clobber
+            gh release edit "$tag" \
+              --title "Governance Platform v${VERSION}" \
+              --notes-file dist/release-notes.md \
+              "${flags[@]}"
+          else
+            gh release create "$tag" "${assets[@]}" \
+              --title "Governance Platform v${VERSION}" \
+              --notes-file dist/release-notes.md \
+              --verify-tag \
+              "${flags[@]}"
+          fi

--- a/charts/auth-service/templates/_helpers.tpl
+++ b/charts/auth-service/templates/_helpers.tpl
@@ -42,3 +42,27 @@ Selector labels
 app.kubernetes.io/name: {{ include "auth-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Resolve the image repository, honoring customer registry mirror overrides.
+*/}}
+{{- define "auth-service.imageRepository" -}}
+{{- $repository := .Values.image.repository -}}
+{{- $registryOverride := default "" ((.Values.global).imageRegistryOverride) -}}
+{{- $prefixOverride := default "" ((.Values.global).imageRepositoryPrefixOverride) -}}
+{{- if $prefixOverride -}}
+{{- printf "%s/%s" (trimSuffix "/" $prefixOverride) (base $repository) -}}
+{{- else if $registryOverride -}}
+{{- $parts := splitList "/" $repository -}}
+{{- printf "%s/%s" (trimSuffix "/" $registryOverride) (join "/" (slice $parts 1)) -}}
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the full image reference.
+*/}}
+{{- define "auth-service.image" -}}
+{{- printf "%s:%s" (include "auth-service.imageRepository" .) (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/auth-service/templates/deployment.yaml
+++ b/charts/auth-service/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "auth-service.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default ((.Values.global).imagePullPolicy | default "IfNotPresent") }}
           ports:
             - name: http

--- a/charts/auth-service/templates/migration-job.yaml
+++ b/charts/auth-service/templates/migration-job.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       containers:
         - name: migrate
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "auth-service.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/migrate"]
           env:

--- a/charts/auth-service/values.yaml
+++ b/charts/auth-service/values.yaml
@@ -13,6 +13,13 @@
 # Enable the Auth Service
 enabled: true
 
+# -- Global values shared by umbrella and standalone installs
+global:
+  # -- Replace only the image registry host, for example registry.customer.example
+  imageRegistryOverride: ""
+  # -- Replace the full EQTY image repository prefix, for example registry.customer.example/eqtylab
+  imageRepositoryPrefixOverride: ""
+
 # -- Replica Count
 # @default -- `2`
 # Number of pod replicas to run (ignored if autoscaling.enabled is true)

--- a/charts/governance-platform/values.yaml
+++ b/charts/governance-platform/values.yaml
@@ -36,6 +36,14 @@ global:
   # - Never: Never pull, use local image only
   imagePullPolicy: "IfNotPresent"
 
+  # -- Replace only the image registry host for EQTY runtime images.
+  # Example: registry.customer.example
+  imageRegistryOverride: ""
+
+  # -- Replace the full EQTY image repository prefix for mirrored installs.
+  # Example: registry.customer.example/eqtylab
+  imageRepositoryPrefixOverride: ""
+
   # -- Image Pull Secrets
   # @default -- `[{"name": "platform-image-pull-secret"}]`
   # Secrets for accessing private container registries

--- a/charts/governance-service/templates/_helpers.tpl
+++ b/charts/governance-service/templates/_helpers.tpl
@@ -42,3 +42,27 @@ Selector labels
 app.kubernetes.io/name: {{ include "governance-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Resolve the image repository, honoring customer registry mirror overrides.
+*/}}
+{{- define "governance-service.imageRepository" -}}
+{{- $repository := .Values.image.repository -}}
+{{- $registryOverride := default "" ((.Values.global).imageRegistryOverride) -}}
+{{- $prefixOverride := default "" ((.Values.global).imageRepositoryPrefixOverride) -}}
+{{- if $prefixOverride -}}
+{{- printf "%s/%s" (trimSuffix "/" $prefixOverride) (base $repository) -}}
+{{- else if $registryOverride -}}
+{{- $parts := splitList "/" $repository -}}
+{{- printf "%s/%s" (trimSuffix "/" $registryOverride) (join "/" (slice $parts 1)) -}}
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the full image reference.
+*/}}
+{{- define "governance-service.image" -}}
+{{- printf "%s:%s" (include "governance-service.imageRepository" .) (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/governance-service/templates/deployment.yaml
+++ b/charts/governance-service/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "governance-service.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default ((.Values.global).imagePullPolicy | default "IfNotPresent") }}
           command: {{ .Values.command }}
           args: {{ .Values.args }}

--- a/charts/governance-service/values.yaml
+++ b/charts/governance-service/values.yaml
@@ -12,6 +12,13 @@
 # Enable the Governance Service backend API
 enabled: true
 
+# -- Global values shared by umbrella and standalone installs
+global:
+  # -- Replace only the image registry host, for example registry.customer.example
+  imageRegistryOverride: ""
+  # -- Replace the full EQTY image repository prefix, for example registry.customer.example/eqtylab
+  imageRepositoryPrefixOverride: ""
+
 # -- Replica Count
 # @default -- `2`
 # Number of pod replicas to run (ignored if autoscaling.enabled is true)

--- a/charts/governance-studio/templates/_helpers.tpl
+++ b/charts/governance-studio/templates/_helpers.tpl
@@ -42,3 +42,27 @@ Selector labels
 app.kubernetes.io/name: {{ include "governance-studio.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Resolve the image repository, honoring customer registry mirror overrides.
+*/}}
+{{- define "governance-studio.imageRepository" -}}
+{{- $repository := .Values.image.repository -}}
+{{- $registryOverride := default "" ((.Values.global).imageRegistryOverride) -}}
+{{- $prefixOverride := default "" ((.Values.global).imageRepositoryPrefixOverride) -}}
+{{- if $prefixOverride -}}
+{{- printf "%s/%s" (trimSuffix "/" $prefixOverride) (base $repository) -}}
+{{- else if $registryOverride -}}
+{{- $parts := splitList "/" $repository -}}
+{{- printf "%s/%s" (trimSuffix "/" $registryOverride) (join "/" (slice $parts 1)) -}}
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the full image reference.
+*/}}
+{{- define "governance-studio.image" -}}
+{{- printf "%s:%s" (include "governance-studio.imageRepository" .) (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/governance-studio/templates/deployment.yaml
+++ b/charts/governance-studio/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       initContainers:
         - name: copy-assets
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "governance-studio.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - sh
@@ -72,7 +72,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "governance-studio.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/governance-studio/values.yaml
+++ b/charts/governance-studio/values.yaml
@@ -12,6 +12,13 @@
 # Enable the Governance Studio frontend application
 enabled: true
 
+# -- Global values shared by umbrella and standalone installs
+global:
+  # -- Replace only the image registry host, for example registry.customer.example
+  imageRegistryOverride: ""
+  # -- Replace the full EQTY image repository prefix, for example registry.customer.example/eqtylab
+  imageRepositoryPrefixOverride: ""
+
 # -- Replica Count
 # @default -- `1`
 # Number of pod replicas to run (ignored if autoscaling.enabled is true)

--- a/charts/integrity-service/templates/_helpers.tpl
+++ b/charts/integrity-service/templates/_helpers.tpl
@@ -42,3 +42,27 @@ Selector labels
 app.kubernetes.io/name: {{ include "integrity-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Resolve the image repository, honoring customer registry mirror overrides.
+*/}}
+{{- define "integrity-service.imageRepository" -}}
+{{- $repository := .Values.image.repository -}}
+{{- $registryOverride := default "" ((.Values.global).imageRegistryOverride) -}}
+{{- $prefixOverride := default "" ((.Values.global).imageRepositoryPrefixOverride) -}}
+{{- if $prefixOverride -}}
+{{- printf "%s/%s" (trimSuffix "/" $prefixOverride) (base $repository) -}}
+{{- else if $registryOverride -}}
+{{- $parts := splitList "/" $repository -}}
+{{- printf "%s/%s" (trimSuffix "/" $registryOverride) (join "/" (slice $parts 1)) -}}
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the full image reference.
+*/}}
+{{- define "integrity-service.image" -}}
+{{- printf "%s:%s" (include "integrity-service.imageRepository" .) (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/integrity-service/templates/deployment.yaml
+++ b/charts/integrity-service/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "integrity-service.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "integrity-service"

--- a/charts/integrity-service/values.yaml
+++ b/charts/integrity-service/values.yaml
@@ -13,6 +13,13 @@
 # Enable the Integrity Service for lineage and verifiable credentials
 enabled: true
 
+# -- Global values shared by umbrella and standalone installs
+global:
+  # -- Replace only the image registry host, for example registry.customer.example
+  imageRegistryOverride: ""
+  # -- Replace the full EQTY image repository prefix, for example registry.customer.example/eqtylab
+  imageRepositoryPrefixOverride: ""
+
 # -- Replica Count
 # @default -- `2`
 # Number of pod replicas to run (ignored if autoscaling.enabled is true)

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,10 @@
+# Governance Platform Docsite Source
+
+This directory contains source-controlled customer documentation for the
+ReadMe-hosted Governance Platform docsite.
+
+For `v0.1.0`, publish the ReadMe version as `v0.1.0`, mark it Beta, and keep it
+non-default until the release is considered generally supported.
+
+The GitHub release and release manifest are the source of truth for artifact
+versions, image digests, chart versions, and package checksums.

--- a/docs-site/readme/guides/install/airgap-install.md
+++ b/docs-site/readme/guides/install/airgap-install.md
@@ -1,0 +1,18 @@
+# Air-Gapped Install
+
+Air-gapped installs mirror the runtime images listed in the release manifest to
+a customer registry and install the platform with registry override values.
+
+## Registry Override
+
+Use `global.imageRepositoryPrefixOverride` when all EQTY images are mirrored
+under the same customer registry prefix:
+
+```yaml
+global:
+  imageRepositoryPrefixOverride: registry.customer.example/eqtylab
+```
+
+For v0.1.0, air-gap package generation is package-ready optional. The connected
+package includes the chart and manifest information needed to prepare a mirrored
+install path.

--- a/docs-site/readme/guides/install/connected-install.md
+++ b/docs-site/readme/guides/install/connected-install.md
@@ -1,0 +1,27 @@
+# Connected Install
+
+Connected installs pull public Helm charts from GHCR and private runtime images
+from GHCR using customer-specific image pull credentials.
+
+## Prerequisites
+
+- Kubernetes 1.29 or newer
+- Helm 3.20 or newer
+- External Postgres
+- Ingress and TLS configured for the customer domain
+- Image pull credentials for `ghcr.io/eqtylab`
+
+## Install
+
+Use the platform version from the release manifest:
+
+```bash
+helm upgrade --install governance-platform oci://ghcr.io/eqtylab/charts/governance-platform \
+  --version 0.1.0 \
+  --namespace governance \
+  --create-namespace \
+  --values values.yaml
+```
+
+After install, verify pods are ready and then validate the Studio login path and
+backend health endpoints.

--- a/docs-site/readme/guides/operate/known-issues.md
+++ b/docs-site/readme/guides/operate/known-issues.md
@@ -1,0 +1,12 @@
+# Known Issues
+
+This page must be reviewed for every platform release before the customer
+package is published.
+
+For v0.1.0:
+
+- ReadMe publishing may be manual while CI enforces source-controlled docs.
+- Air-gap image archive export may be delivered after the connected package
+  workflow is operational.
+- OpenAPI reference publishing is phased and should include only
+  customer-supported endpoints.

--- a/docs-site/readme/guides/release-overview.md
+++ b/docs-site/readme/guides/release-overview.md
@@ -1,0 +1,32 @@
+# Governance Platform v0.1.0
+
+Governance Platform v0.1.0 is a customer prerelease. It is delivered as private
+runtime images, public Helm charts, a release manifest, and a connected customer
+package.
+
+Use only the chart version and image tags recorded in the release manifest. Do
+not install from floating image tags.
+
+## Release Status
+
+- Status: Beta prerelease
+- Kubernetes: 1.29 or newer
+- Architecture: linux/amd64
+- Primary install path: `governance-platform` umbrella chart
+- Runtime image access: private GHCR credentials or customer registry mirror
+- Manual validation path: Keycloak with external Postgres
+
+## Included Runtime Services
+
+- Governance Studio
+- Governance Service
+- Auth Service
+- Integrity Service
+
+## Customer Artifacts
+
+- `governance-platform-v0.1.0.tar.gz`
+- `release-manifest.yaml`
+- `chart-digests.yaml`
+- chart packages and checksums
+- install examples

--- a/docs-site/readme/guides/upgrade/rollback.md
+++ b/docs-site/readme/guides/upgrade/rollback.md
@@ -1,0 +1,13 @@
+# Rollback
+
+Rollback depends on database migration behavior for the release being rolled
+back. Always capture a Postgres backup before upgrade.
+
+General rollback shape:
+
+```bash
+helm rollback governance-platform <REVISION> --namespace governance
+```
+
+If database migrations are not reversible, restore the database backup and then
+roll back the Helm release.

--- a/docs-site/readme/guides/upgrade/upgrade.md
+++ b/docs-site/readme/guides/upgrade/upgrade.md
@@ -1,0 +1,14 @@
+# Upgrade
+
+Upgrade support for v0.1.0 is limited because this is the first customer
+prerelease line.
+
+Before upgrading a customer environment:
+
+1. Back up Postgres.
+2. Save the current Helm values.
+3. Confirm the target release manifest.
+4. Confirm all runtime images are available in the selected registry.
+5. Run `helm diff` or an equivalent review.
+
+Use the exact chart version from the release manifest when upgrading.

--- a/docs-site/readme/recipes/keycloak.md
+++ b/docs-site/readme/recipes/keycloak.md
@@ -1,0 +1,14 @@
+# Keycloak Manual Validation Recipe
+
+Keycloak is the first required identity provider path for release-candidate
+validation. This check is performed by the release owner and recorded in the
+release manifest before customer publication.
+
+Use the Keycloak values examples in the Governance Platform chart, provide
+external Postgres settings, and verify:
+
+- Auth Service health
+- Governance Service health
+- Integrity Service health
+- Studio load
+- Login redirect and return flow

--- a/docs-site/readme/recipes/private-registry.md
+++ b/docs-site/readme/recipes/private-registry.md
@@ -1,0 +1,11 @@
+# Private Registry Recipe
+
+Runtime images are private by default.
+
+Connected customers can use GHCR pull credentials. Disconnected customers should
+mirror the image digests recorded in the release manifest and set:
+
+```yaml
+global:
+  imageRepositoryPrefixOverride: registry.customer.example/eqtylab
+```

--- a/docs-site/readme/reference/helm-values.md
+++ b/docs-site/readme/reference/helm-values.md
@@ -1,0 +1,14 @@
+# Helm Values
+
+Helm values are generated from the chart source during release preparation.
+
+Important customer-facing values:
+
+- `global.imagePullSecrets`
+- `global.secrets.imageRegistry`
+- `global.imageRegistryOverride`
+- `global.imageRepositoryPrefixOverride`
+- service-level `image.repository`
+- service-level `image.tag`
+
+Prefer the global repository prefix override for air-gapped installs.

--- a/docs-site/readme/reference/release-manifest.md
+++ b/docs-site/readme/reference/release-manifest.md
@@ -1,0 +1,32 @@
+# Release Manifest
+
+The release manifest records the exact customer release contents.
+
+Required sections:
+
+- `platform`
+- `sources`
+- `images`
+- `charts`
+- `validation`
+- `docs`
+
+Each runtime image entry must include:
+
+- repository
+- tag
+- digest
+- source SHA
+
+Each chart entry must include:
+
+- chart name
+- chart version
+- OCI reference
+
+The validation section records the manual customer-like validation gate. A
+candidate starts with `validation.evidence.status: pending`. Customer
+publication requires `validation.evidence.status: approved`.
+
+The release package and GitHub Release must include the manifest used to publish
+the customer artifacts.

--- a/schemas/release-manifest.schema.json
+++ b/schemas/release-manifest.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/eqtylab/deployment/schemas/release-manifest.schema.json",
+  "title": "Governance Platform Release Manifest",
+  "type": "object",
+  "required": ["platform", "sources", "images", "charts", "validation", "docs"],
+  "properties": {
+    "platform": {
+      "type": "object",
+      "required": ["name", "version", "releaseType", "kubernetesMinimumVersion", "architecture"],
+      "properties": {
+        "name": { "const": "governance-platform" },
+        "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+([-.][0-9A-Za-z.-]+)?$" },
+        "releaseType": { "enum": ["prerelease", "stable"] },
+        "releaseDate": { "type": "string" },
+        "kubernetesMinimumVersion": { "type": "string" },
+        "architecture": { "const": "linux/amd64" }
+      }
+    },
+    "images": {
+      "type": "object",
+      "required": ["authService", "governanceService", "governanceStudio", "integrityService"],
+      "additionalProperties": {
+        "type": "object",
+        "required": ["repository", "tag", "digest", "sourceSha"],
+        "properties": {
+          "repository": { "type": "string" },
+          "tag": { "type": "string" },
+          "digest": { "type": "string" },
+          "sourceSha": { "type": "string" }
+        }
+      }
+    },
+    "charts": { "type": "object" },
+    "sources": { "type": "object" },
+    "validation": {
+      "type": "object",
+      "required": ["required", "mode", "identityProvider", "database", "evidence"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "mode": { "const": "manual" },
+        "identityProvider": { "type": "string" },
+        "database": { "type": "string" },
+        "evidence": {
+          "type": "object",
+          "required": ["status", "recordedIn"],
+          "properties": {
+            "status": { "enum": ["pending", "approved", "rejected"] },
+            "recordedIn": { "type": "string" },
+            "reviewer": { "type": "string" },
+            "reviewedAt": { "type": "string" },
+            "notes": { "type": "string" }
+          }
+        }
+      }
+    },
+    "docs": {
+      "type": "object",
+      "required": ["provider", "version", "state"],
+      "properties": {
+        "provider": { "const": "readme" },
+        "version": { "type": "string" },
+        "state": { "enum": ["beta", "public", "hidden", "deprecated"] },
+        "default": { "type": "boolean" },
+        "sourceRepository": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the deployment-side customer package, chart, and docsite release surface for Governance Platform v0.1.0.

- Adds Helm CI for charts, examples, registry overrides, and release manifests
- Adds `release-platform-package.yaml` for publishing charts, packages, checksums, attestations, and GitHub releases
- Adds docs-site source scaffold for ReadMe versioned documentation
- Adds release manifest schema with manual validation evidence contract
- Mirrors chart image registry override support from infrastructure

## Validation

- YAML syntax validated locally
- JSON schema syntax validated locally
- actionlint passed for touched workflows
- Helm dependency build/lint/template validation passed from a clean temp checkout
- Local docsite markdown links validated

## Cross-Repository PR Set

- Governance Studio image workflow: https://github.com/eqtylab/governance-studio/pull/639
- Governance Backend image workflows: https://github.com/eqtylab/governance-backend/pull/289
- Integrity Service image workflow: https://github.com/eqtylab/integrity-monorepo/pull/1643
- Infrastructure release orchestration and chart source of truth: https://github.com/eqtylab/governance-studio-infrastructure/pull/70
- Deployment customer package, chart, and docs publication: https://github.com/eqtylab/deployment/pull/9

## Suggested Merge Order

1. Component image workflow PRs: Studio, Backend, Integrity
2. Infrastructure orchestration PR
3. Deployment publication PR

This PR is the customer-facing publication surface. It can be reviewed in parallel, but final publication should happen only after the infrastructure release candidate flow and manual validation evidence are accepted.